### PR TITLE
replace cx addons to classnames

### DIFF
--- a/client/app/components/nav/nav.js
+++ b/client/app/components/nav/nav.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var React = require('react/addons');
+var classnames = require('classnames');
 
 var Nav = React.createClass({
   getInitialState: function () {
@@ -30,13 +31,10 @@ var Nav = React.createClass({
     });
   },
   render: function () {
-    var cx = React.addons.classSet;
-    var logoClass = cx({
-      'nav-logo': true,
+    var logoClass = classnames('nav-logo', {
       'hide': !this.state.hideMenu
     });
-    var menuClass = cx({
-      'nav-menu': true,
+    var menuClass = classnames('nav-menu', {
       'hide': this.state.hideMenu
     });
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "bluebird": "^2.9.27",
     "body-parser": "~1.12.4",
+    "classnames": "^2.1.2",
     "connect-browserify": "^4.0.0",
     "express": "~4.12.4",
     "express-session": "^1.11.2",


### PR DESCRIPTION
eliminate `React.addons.classSet` deprecated warning
